### PR TITLE
Updated the effects section to grab the actual label and localize it

### DIFF
--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -344,11 +344,12 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         _getStatuses(parent, default_statuses) {
             let actions = [];
             default_statuses.forEach(_status => {
-                let img = CONFIG.statusEffects.find((el) => el.id ===_status.toLowerCase())?.icon ?? null;
+                let statusEffect = CONFIG.statusEffects.find((el) => el.id ===_status.toLowerCase())
+                let img = statusEffect?.icon ?? null;
                 
                 let action =  {
                     id: _status.toLowerCase(),
-                    name: _status,
+                    name: statusEffect ? game.i18n.localize(statusEffect.label) : _status,
                     cssClass: this.actor.statuses.has(_status.toLowerCase()) ? "toggle active" : "togle",
                     img: img,
                     description: _status,

--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -1,4 +1,5 @@
 import { ATTRIBUTE_ID, ICONSDIR, IMG_DICE, init_help_buttons, MAIN_ACTIONS, FREE_ACTIONS } from './constants.js'
+import { Utils } from './utils.js'
 export let SavageActionHandler = null
 
 Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
@@ -262,8 +263,8 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                     const data = a[1];
                     let img = IMG_DICE + 'd' + data.die.sides + '.svg'
                     actions.push({
-                        id:key,
-                        name: coreModule.api.Utils.i18n(key),
+                        id: key,
+                        name: Utils.getLocalizedAttributeName(key),
                         img: img,
                         description: coreModule.api.Utils.i18n('SWADE.Attributes'),
                         encodedValue: [macroType, key].join(this.delimiter),

--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -344,7 +344,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         _getStatuses(parent, default_statuses) {
             let actions = [];
             default_statuses.forEach(_status => {
-                let statusEffect = CONFIG.statusEffects.find((el) => el.id ===_status.toLowerCase())
+                let statusEffect = CONFIG.statusEffects.find((el) => el.id === _status)
                 let img = statusEffect?.icon ?? null;
                 
                 let action =  {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -33,5 +33,25 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                 coreModule.api.Logger.debug(`Setting '${key}' not found`)
             }
         }
+    
+        /**
+         * Returns the localized string for a given attribute
+         * @param {string} attribute The id of the attribute 
+         */
+        static getLocalizedAttributeName(attribute) {
+            if (attribute === "agility") {
+                return game.i18n.localize("SWADE.AttrAgi");
+            } else if (attribute === "smarts") {
+                return game.i18n.localize("SWADE.AttrSma");
+            } else if (attribute === "spirit") {
+                return game.i18n.localize("SWADE.AttrSpr");
+            } else if (attribute === "strength") {
+                return game.i18n.localize("SWADE.AttrStr");
+            } else if (attribute === "vigor") {
+                return game.i18n.localize("SWADE.AttrVig");
+            }
+    
+            return "Invalid Attribute";
+        }
     }
 })


### PR DESCRIPTION
This change makes the status effects human readable and localized. Prior to this, it was just using the effect ids which was especially a problem with effects added through SUCC as they have a generated GUID. This also required the removal of the toLower on the id compare which was unnecessary and would have broken on any status effect with an id that wasn't lowercase since defaults_statuses is populated directly from CONFIG.statusEffects anyway.

As an aside, IMO it would be cleaner if _effects and everything down the chain just used the contents of statusEffects rather than the ids. Right now, we convert the array of effects into an array of ids and then use that array of ids to look up the effect back in the original array. I wanted to minimize my changes, though, so I left it as is. Just a suggestion for something to look at if you're looking to clean up the code at any point.